### PR TITLE
Rename <eventName> props to <onEventName>

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/keokilee/react-electron-webview#readme",
   "dependencies": {
-    "camelcase": "^2.0.1"
+    "camelcase": "^4.0.0"
   },
   "devDependencies": {
     "babel": "^6.3.26",
@@ -32,19 +32,19 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-register": "^6.3.13",
-    "electron-prebuilt": "^0.36.2",
+    "electron-prebuilt": "^1.4.6",
     "expect": "^1.13.4",
-    "karma": "^0.13.16",
+    "karma": "^1.3.0",
     "karma-electron-launcher": "^0.1.0",
-    "karma-mocha": "^0.2.1",
+    "karma-mocha": "^1.3.0",
     "karma-sourcemap-loader": "^0.3.6",
-    "karma-spec-reporter": "0.0.23",
+    "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^1.7.0",
-    "mocha": "^2.3.4",
-    "react": "^0.14.5",
-    "react-addons-test-utils": "^0.14.5",
-    "react-dom": "^0.14.5",
-    "webpack": "^1.12.9",
-    "semantic-release": "^4.3.5"
+    "mocha": "^3.1.2",
+    "react": "^15.3.2",
+    "react-addons-test-utils": "^15.3.2",
+    "react-dom": "^15.3.2",
+    "semantic-release": "^4.3.5",
+    "webpack": "^1.12.9"
   }
 }

--- a/src/webview.js
+++ b/src/webview.js
@@ -26,6 +26,10 @@ const EVENTS = [
   'destroyed'
 ];
 
+const HANDLERS = EVENTS.map(event => camelCase(`on-${event}`));
+
+const EVENTS_HANDLERS = EVENTS.map((event, i) => ({ event, handler: HANDLERS[i] }));
+
 export default class WebView extends React.Component {
   constructor(props) {
     super(props);
@@ -47,7 +51,9 @@ export default class WebView extends React.Component {
 
   // Private methods
   _bindEvents(node) {
-    EVENTS.forEach(event => node.addEventListener(event, this.props[camelCase(event)]));
+    for (const { event, handler } of EVENTS_HANDLERS) {
+      node.addEventListener(event, this.props[handler]);
+    }
   }
 
   _assignMethods(node) {
@@ -59,7 +65,7 @@ export default class WebView extends React.Component {
   }
 }
 
-WebView.propTypes = {
+const tagPropTypes = {
   autosize: React.PropTypes.bool,
   disablewebsecurity: React.PropTypes.bool,
   httpreferrer: React.PropTypes.string,
@@ -70,4 +76,9 @@ WebView.propTypes = {
   useragent: React.PropTypes.string
 };
 
-EVENTS.reduce((propTypes, event) => propTypes[camelCase(event)] = React.PropTypes.func, WebView.propTypes);
+const eventPropTypes = EVENTS_HANDLERS.reduce((propTypes, { event, handler }) => {
+  propTypes[handler] = React.PropTypes.func;
+  return propTypes;
+}, {});
+
+WebView.propTypes = Object.assign({}, tagPropTypes, eventPropTypes);

--- a/src/webview.js
+++ b/src/webview.js
@@ -30,6 +30,15 @@ const HANDLERS = EVENTS.map(event => camelCase(`on-${event}`));
 
 const EVENTS_HANDLERS = EVENTS.map((event, i) => ({ event, handler: HANDLERS[i] }));
 
+function filterKeys(object, filterFunc) {
+  return Object.keys(object)
+    .filter(filterFunc)
+    .reduce((filtered, key) => {
+      filtered[key] = object[key];
+      return filtered;
+    }, {});
+}
+
 export default class WebView extends React.Component {
   constructor(props) {
     super(props);
@@ -46,7 +55,8 @@ export default class WebView extends React.Component {
   }
 
   render() {
-    return (<webview {...this.props}></webview>);
+    const tagProps = filterKeys(this.props, propName => propName in tagPropTypes)
+    return (<webview {...tagProps}></webview>);
   }
 
   // Private methods

--- a/test/webview.js
+++ b/test/webview.js
@@ -26,8 +26,8 @@ describe('webview', () => {
 
   describe('events', () => {
     it('responds to the load-commit event', () => {
-      const props = {loadCommit: () => true};
-      const spy = spyOn(props, 'loadCommit');
+      const props = {onLoadCommit: () => true};
+      const spy = spyOn(props, 'onLoadCommit');
       const webview = renderWebviewTag(props);
 
       const testEvent = new Event('load-commit');
@@ -36,8 +36,8 @@ describe('webview', () => {
     });
 
     it('responds to the dom-ready event', () => {
-      const props = {domReady: () => true};
-      const spy = spyOn(props, 'domReady');
+      const props = {onDomReady: () => true};
+      const spy = spyOn(props, 'onDomReady');
       const webview = renderWebviewTag(props);
 
       const testEvent = new Event('dom-ready');


### PR DESCRIPTION
also updates dependencies and fixes the event props being passed to the `<webview/>` tag.

these fixes remove all react warnings that previously occurred in the tests. so if there’s a switch to turn on test failure on warnings, it can be toggled now.

after this is pulled, a semver update to 2.0.0 is in order since this renames the event props