### PR TITLE
Fix type for `ref` prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 
 import { Component } from 'react';
 
-export interface WebViewProps extends React.HTMLProps<Electron.WebViewElement> {
+export interface WebViewProps extends React.HTMLAttributes<Electron.WebViewElement>, React.ClassAttributes<WebView> {
   src: string
   
   autosize?: boolean


### PR DESCRIPTION
`HTMLProps` is only intended for HTML Elements. `HTMLProps<AnElement>` means `HTMLAttributes<AnElement> & ClassAttributes<AnElement>`

`ClassAttributes<T>` means something has a `ref: string | (instance: T) => any` property.

A component wrapping an element (like ours) should therefore have props extending

* `HTMLAttributes<WrappedElement>` (for the element props it passes on), and
* `ClassAttributes<Wrapper>` (for the ref function `ref={wrapper => ...}`)

sorry for the mistake! I didn’t want to cause you maintainance stress by including those typings!